### PR TITLE
FEAT: Versioned libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build
 **/build
-.install
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 **/build
 .vscode
+.project_libraries

--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -5,10 +5,17 @@ project(app VERSION 0.1.0)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-## If you want to have a custom path, set the variable below
-#set(CMAKE_PREFIX_PATH "/path/to/someLibrary/install")
-find_package(someLibA 1.0.9 CONFIG REQUIRED)
-find_package(someLibB 3.0.0 CONFIG REQUIRED)
+## Set the path for the CMAKE_PREFIX_PATH variable below
+set(someLibA_NAME   someLibA)
+set(someLibA_VERSION   1.0.9)
+list(APPEND CMAKE_PREFIX_PATH "/path/to/someLibrary/.project_libraries/cmake/${someLibA_NAME}-${someLibA_VERSION}")
+find_package(${someLibA_NAME} ${someLibA_VERSION} CONFIG REQUIRED)
+
+set(someLibB_NAME   someLibB)
+set(someLibB_VERSION   3.0.0)
+list(APPEND CMAKE_PREFIX_PATH "/path/to/someLibrary/.project_libraries/cmake/${someLibB_NAME}-${someLibB_VERSION}")
+find_package(${someLibB_NAME} ${someLibB_VERSION} CONFIG REQUIRED)
+
 
 add_executable(${PROJECT_NAME})
 

--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -2,18 +2,25 @@ cmake_minimum_required(VERSION 3.20)
 
 project(app VERSION 0.1.0)
 
+# Set the project workspace, it's used as a reference for the installed files
+set(PROJECT_WORKSPACE
+    "${CMAKE_CURRENT_SOURCE_DIR}/.."
+    CACHE PATH "Project workspace"
+)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-## Set the path for the CMAKE_PREFIX_PATH variable below
+## someLibA info
 set(someLibA_NAME   someLibA)
 set(someLibA_VERSION   1.0.9)
-list(APPEND CMAKE_PREFIX_PATH "/path/to/someLibrary/.project_libraries/cmake/${someLibA_NAME}-${someLibA_VERSION}")
+list(APPEND CMAKE_PREFIX_PATH "${PROJECT_WORKSPACE}/.project_libraries/cmake/${someLibA_NAME}-${someLibA_VERSION}")
 find_package(${someLibA_NAME} ${someLibA_VERSION} CONFIG REQUIRED)
 
+## someLibB info
 set(someLibB_NAME   someLibB)
 set(someLibB_VERSION   3.0.0)
-list(APPEND CMAKE_PREFIX_PATH "/path/to/someLibrary/.project_libraries/cmake/${someLibB_NAME}-${someLibB_VERSION}")
+list(APPEND CMAKE_PREFIX_PATH "${PROJECT_WORKSPACE}/.project_libraries/cmake/${someLibB_NAME}-${someLibB_VERSION}")
 find_package(${someLibB_NAME} ${someLibB_VERSION} CONFIG REQUIRED)
 
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Furthermore, the following topics represents the dependency chain:
 - `App` depends on the `someLibA` and `someLibB`
 
 
+_**NOTE:** Tested on macOS/Ubuntu, this may not work on Windows_
 
 ## Project Structure
 

--- a/someLibA/CMakeLists.txt
+++ b/someLibA/CMakeLists.txt
@@ -4,6 +4,11 @@ cmake_minimum_required(VERSION 3.20.0)
 set(namespace "someLibA")
 project(someLibA VERSION 1.0.9 LANGUAGES CXX)
 
+# Set the project workspace, it's used as a reference for the installed files
+set(PROJECT_WORKSPACE
+    "${CMAKE_CURRENT_SOURCE_DIR}/.."
+    CACHE PATH "Project workspace"
+)
 
 add_library(${PROJECT_NAME} STATIC)
 

--- a/someLibA/Config.cmake.in
+++ b/someLibA/Config.cmake.in
@@ -1,6 +1,0 @@
-@PACKAGE_INIT@
-
-include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
-
-# Check whether or not all the required components were found
-check_required_components(@PROJECT_NAME@)

--- a/someLibA/cmake/Config.cmake.in
+++ b/someLibA/cmake/Config.cmake.in
@@ -1,7 +1,4 @@
 # - Config file for the someLibA package
-# It defines the following variables
-#  someLibA_INCLUDE_DIRS - include directories for someLibA
-#  someLibA_LIBRARIES    - libraries to link against
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/someLibA/cmake/Config.cmake.in
+++ b/someLibA/cmake/Config.cmake.in
@@ -1,0 +1,10 @@
+# - Config file for the someLibA package
+# It defines the following variables
+#  someLibA_INCLUDE_DIRS - include directories for someLibA
+#  someLibA_LIBRARIES    - libraries to link against
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+
+# Check whether or not all the required components were found
+check_required_components(@PROJECT_NAME@)

--- a/someLibA/cmake/Installing.cmake
+++ b/someLibA/cmake/Installing.cmake
@@ -8,11 +8,17 @@ if(DEFINED CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
         STATUS
         "CMAKE_INSTALL_PREFIX is not set\n"
         "Default value: ${CMAKE_INSTALL_PREFIX}\n"
-        "Will set it to ${CMAKE_SOURCE_DIR}/../.install"
+        "Will set it to ${PROJECT_WORKSPACE}/.project_libraries"
     )
+
     set(CMAKE_INSTALL_PREFIX
-        "${CMAKE_SOURCE_DIR}/../.install"
+        "${PROJECT_WORKSPACE}/.project_libraries"
         CACHE PATH "Where the library will be installed to" FORCE
+    )
+
+    set(${PROJECT_NAME}_DIR
+    "${CMAKE_INSTALL_PREFIX}/cmake/${PROJECT_NAME}-${PROJECT_VERSION}"
+    CACHE PATH "Where the library will be installed to" FORCE
     )
 else()
     message(
@@ -31,8 +37,8 @@ install(TARGETS ${PROJECT_NAME}
     EXPORT "${PROJECT_NAME}Targets"
     # these get default values from GNUInstallDirs, no need to set them
     #RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} # bin
-    #LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} # lib
-    #ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} # lib
+    # LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} # lib - meant for shared libraries
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}-${PROJECT_VERSION} # lib
     # except for public headers, as we want them to be inside a library folder
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME} # include/SomeProject
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} # include
@@ -42,30 +48,25 @@ install(TARGETS ${PROJECT_NAME}
 install(EXPORT "${PROJECT_NAME}Targets"
     FILE "${PROJECT_NAME}Targets.cmake"
     NAMESPACE ${namespace}::
-    DESTINATION cmake
+    DESTINATION cmake/${PROJECT_NAME}-${PROJECT_VERSION}
 )
 
-# # # include(CMakePackageConfigHelpers)
+include(CMakePackageConfigHelpers)
 
-# # # # generate the version file for the config file
-# # # write_basic_package_version_file(
-# # #     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-# # #     COMPATIBILITY AnyNewerVersion
-# # # )
-# # # # create config file
-# # # configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
-# # #     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-# # #     INSTALL_DESTINATION cmake
-# # # )
-# # # # install config files
-# # # install(FILES
-# # #     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-# # #     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-# # #     DESTINATION cmake
-# # # )
-# generate the export targets for the build tree
-# (can't say what this one is for, but so far it has been only causing me problems)
-# export(EXPORT "${PROJECT_NAME}Targets"
-#     FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Targets.cmake"
-#     NAMESPACE ${namespace}::
-# )
+# generate the version file for the config file
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+# create config file
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION cmake/${PROJECT_NAME}-${PROJECT_VERSION}
+)
+# install config files
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION cmake/${PROJECT_NAME}-${PROJECT_VERSION}
+)

--- a/someLibA/example/CMakeLists.txt
+++ b/someLibA/example/CMakeLists.txt
@@ -2,12 +2,20 @@ cmake_minimum_required(VERSION 3.20)
 
 project(app VERSION 0.1.0)
 
+# Set the project workspace, it's used as a reference for the installed files
+set(PROJECT_WORKSPACE
+    "${CMAKE_CURRENT_SOURCE_DIR}/../.."
+    CACHE PATH "Project workspace"
+)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-## If you want to have a custom path, set the variable below
-#set(CMAKE_PREFIX_PATH "/usr/lib/local")
-find_package(someLibA 1.0.9 CONFIG REQUIRED)
+## someLibA info
+set(someLibA_NAME   someLibA)
+set(someLibA_VERSION   1.0.9)
+list(APPEND CMAKE_PREFIX_PATH "${PROJECT_WORKSPACE}/.project_libraries/cmake/${someLibA_NAME}-${someLibA_VERSION}")
+find_package(${someLibA_NAME} ${someLibA_VERSION} CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME})
 

--- a/someLibB/CMakeLists.txt
+++ b/someLibB/CMakeLists.txt
@@ -4,6 +4,11 @@ cmake_minimum_required(VERSION 3.20.0)
 set(namespace "someLibB")
 project(someLibB VERSION 3.0.0 LANGUAGES CXX)
 
+# Set the project workspace, it's used as a reference for the installed files
+set(PROJECT_WORKSPACE
+    "${CMAKE_CURRENT_SOURCE_DIR}/.."
+    CACHE PATH "Project workspace"
+)
 
 add_library(${PROJECT_NAME} STATIC)
 
@@ -30,17 +35,13 @@ set(public_headers
     include/someLibB.hpp
 )
 
+## someLibA info
+set(someLibA_NAME   someLibA)
+set(someLibA_VERSION   1.0.9)
+list(APPEND CMAKE_PREFIX_PATH "${PROJECT_WORKSPACE}/.project_libraries/cmake/${someLibA_NAME}-${someLibA_VERSION}")
+find_package(${someLibA_NAME} ${someLibA_VERSION} CONFIG REQUIRED)
 
-
-### Fetching someLibA
-## If you want to have a custom path, set the variable below
-# set(CMAKE_PREFIX_PATH "/usr/lib/local")
-find_package(someLibA 1.0.9 CONFIG REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE someLibA::someLibA)
-
-
-
-
 
 # where to find our CMake modules
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/someLibB/cmake/Config.cmake.in
+++ b/someLibB/cmake/Config.cmake.in
@@ -4,7 +4,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 
 
 # Add dependency on LibA
-include("${CMAKE_CURRENT_LIST_DIR}/someLibATargets.cmake")
+include("@someLibA_DIR@/someLibATargets.cmake")
 
 # Check whether or not all the required components were found
 check_required_components(@PROJECT_NAME@)

--- a/someLibB/cmake/Installing.cmake
+++ b/someLibB/cmake/Installing.cmake
@@ -8,11 +8,17 @@ if(DEFINED CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
         STATUS
         "CMAKE_INSTALL_PREFIX is not set\n"
         "Default value: ${CMAKE_INSTALL_PREFIX}\n"
-        "Will set it to ${CMAKE_SOURCE_DIR}/../.install"
+        "Will set it to ${PROJECT_WORKSPACE}/.project_libraries"
     )
+
     set(CMAKE_INSTALL_PREFIX
-        "${CMAKE_SOURCE_DIR}/../.install"
+        "${PROJECT_WORKSPACE}/.project_libraries"
         CACHE PATH "Where the library will be installed to" FORCE
+    )
+
+    set(${PROJECT_NAME}_DIR
+    "${CMAKE_INSTALL_PREFIX}/cmake/${PROJECT_NAME}-${PROJECT_VERSION}"
+    CACHE PATH "Where the library will be installed to" FORCE
     )
 else()
     message(
@@ -31,8 +37,8 @@ install(TARGETS ${PROJECT_NAME}
     EXPORT "${PROJECT_NAME}Targets"
     # these get default values from GNUInstallDirs, no need to set them
     #RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} # bin
-    #LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} # lib
-    #ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} # lib
+    # LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} # lib - meant for shared libraries
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}-${PROJECT_VERSION} # lib
     # except for public headers, as we want them to be inside a library folder
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME} # include/SomeProject
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} # include
@@ -42,7 +48,7 @@ install(TARGETS ${PROJECT_NAME}
 install(EXPORT "${PROJECT_NAME}Targets"
     FILE "${PROJECT_NAME}Targets.cmake"
     NAMESPACE ${namespace}::
-    DESTINATION cmake
+    DESTINATION cmake/${PROJECT_NAME}-${PROJECT_VERSION}
 )
 
 include(CMakePackageConfigHelpers)
@@ -50,22 +56,17 @@ include(CMakePackageConfigHelpers)
 # generate the version file for the config file
 write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-    COMPATIBILITY AnyNewerVersion
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
 )
 # create config file
-configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-    INSTALL_DESTINATION cmake
+    INSTALL_DESTINATION cmake/${PROJECT_NAME}-${PROJECT_VERSION}
 )
 # install config files
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-    DESTINATION cmake
+    DESTINATION cmake/${PROJECT_NAME}-${PROJECT_VERSION}
 )
-# generate the export targets for the build tree
-# (can't say what this one is for, but so far it has been only causing me problems)
-# export(EXPORT "${PROJECT_NAME}Targets"
-#     FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Targets.cmake"
-#     NAMESPACE ${namespace}::
-# )

--- a/someLibB/example/CMakeLists.txt
+++ b/someLibB/example/CMakeLists.txt
@@ -2,12 +2,20 @@ cmake_minimum_required(VERSION 3.20)
 
 project(app VERSION 0.1.0)
 
+# Set the project workspace, it's used as a reference for the installed files
+set(PROJECT_WORKSPACE
+    "${CMAKE_CURRENT_SOURCE_DIR}/../.."
+    CACHE PATH "Project workspace"
+)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-## If you want to have a custom path, set the variable below
-#set(CMAKE_PREFIX_PATH "usr/lib/local")
-find_package(someLibB 3.0.0 CONFIG REQUIRED)
+## someLibB info
+set(someLibB_NAME   someLibB)
+set(someLibB_VERSION   3.0.0)
+list(APPEND CMAKE_PREFIX_PATH "${PROJECT_WORKSPACE}/.project_libraries/cmake/${someLibB_NAME}-${someLibB_VERSION}")
+find_package(${someLibB_NAME} ${someLibB_VERSION} CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME})
 


### PR DESCRIPTION
## Description

First attempt to support versioned libraries as the following project directories tree:
```bash
$ tree

.project_libraries
├── cmake
│   ├── someLibA-1.0.9
│   │   ├── someLibAConfig.cmake
│   │   ├── someLibAConfigVersion.cmake
│   │   ├── someLibATargets-noconfig.cmake
│   │   └── someLibATargets.cmake
│   └── someLibB-3.0.0
│       ├── someLibBConfig.cmake
│       ├── someLibBConfigVersion.cmake
│       ├── someLibBTargets-noconfig.cmake
│       └── someLibBTargets.cmake
├── include
│   ├── someLibA
│   │   └── someLibA.hpp
│   └── someLibB
│       └── someLibB.hpp
└── lib
    ├── someLibA-1.0.9
    │   └── libsomeLibA.a
    └── someLibB-3.0.0
        └── libsomeLibB.a
```